### PR TITLE
Banner li border colour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "local-election-2018-assets",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/bbc/local-election-2018-assets",
   "authors": [
     "BBC News Data Pres"

--- a/sass/lib/_colours.scss
+++ b/sass/lib/_colours.scss
@@ -7,3 +7,4 @@ $nw-c-grenadier: #d71e00;
 $nw-c-forest-green: #198627;
 $nw-c-nobel: #b3b3b3;
 $nw-c-tapa: #78746e;
+$nw-c-alto: #cfcfcf;


### PR DESCRIPTION
JIRA: https://jira.dev.bbc.co.uk/browse/CONNPOL-4705

Colour doesn't exist in https://github.com/bbc/gs-sass-tools/blob/master/settings/_news-colours.scss or https://github.com/bbc/local-election-2018-assets/blob/master/sass/lib/_colours.scss. Specified in the Sketch markup zip "Local election 2018 Banner mark up.zip" in Dropbox.